### PR TITLE
Update the BBC Launch activity for Android TV

### DIFF
--- a/dist/HA-Firemote.js
+++ b/dist/HA-Firemote.js
@@ -574,7 +574,7 @@ const fastappchoices = {
       "chromecast": {
           "appName": "bbc.iplayer.android",
           "androidName": "bbc.iplayer.android",
-          "adbLaunchCommand": "adb shell am start -n bbc.iplayer.android/uk.co.bbc.iplayer.startup.StartupActivity",
+          "adbLaunchCommand": "adb shell am start -n bbc.iplayer.android/external.androidtv.bbciplayer.deeplinking.DeepLinkActivity",
       },
       "nvidia-shield": {
           "appName": "com.nvidia.bbciplayer",


### PR DESCRIPTION
The old StartupActivity doesn't work any more. This may also be the case on the other platforms but I can't test them so I have not changed them.