### PR TITLE
Add DGO on Apple TV

### DIFF
--- a/dist/launcher-buttons.js
+++ b/dist/launcher-buttons.js
@@ -1945,6 +1945,9 @@ const launcherData = {
           "androidName": 'com.directv.dtvlatam',
           "adbLaunchCommand": "adb shell am start -n com.directv.dtvlatam/com.directvgo.feature.tv.splash.SplashActivity"
       },
+      "apple-tv": {
+          "appName": "DGO",
+      },
       "chromecast": {
           "appName": 'com.directv.dtvlatam',
           "androidName": 'com.directv.dtvlatam',


### PR DESCRIPTION
After adding DGO to chromecast, I took a long vacation, so when I got back I saw that you added it for other android basesd devices, thanks for that!

Now I added it to apple tv aswell.