### PR TITLE
Updated Pluto TV launcher for Roku

### DIFF
--- a/dist/launcher-buttons.js
+++ b/dist/launcher-buttons.js
@@ -6504,7 +6504,7 @@ const launcherData = {
           "adbLaunchCommand": "adb shell am start tv.pluto.android/.EntryPoint",
       },
       "roku": {
-          "appName": "Pluto TV - It's Free TV",
+          "appName": "Pluto TV - Free Movies/Shows",
           "app-id": 74519,
       },
       "xiaomi": {


### PR DESCRIPTION
closes #745

Updated Pluto TV launcher for Roku (name change)