### PR TITLE
Launcher button alias support (including Jellyfin -> Swiftfin)

### DIFF
--- a/dist/HA-Firemote.js
+++ b/dist/HA-Firemote.js
@@ -71,6 +71,64 @@ function resetAppMap(){
 }
 
 
+function resolveAppAlias(appkey, deviceFamily, visited = new Set()) {
+  if(!appmap.has(appkey) || visited.has(appkey)) {
+    return null;
+  }
+  visited.add(appkey);
+  var shortcutData = appmap.get(appkey);
+  var familySpecificAppData = shortcutData[deviceFamily];
+  if(familySpecificAppData && familySpecificAppData.alias) {
+    return resolveAppAlias(familySpecificAppData.alias, deviceFamily, visited);
+  }
+  return {"appkey": appkey, "shortcutData": shortcutData, "familySpecificAppData": familySpecificAppData};
+}
+
+
+function getShortcutLaunchData(appkey, deviceFamily) {
+  var resolvedShortcut = resolveAppAlias(appkey, deviceFamily);
+  if(!resolvedShortcut) {
+    return null;
+  }
+  var familySpecificAppData = resolvedShortcut.familySpecificAppData;
+  if(familySpecificAppData && (familySpecificAppData.adbLaunchCommand || familySpecificAppData.appName || familySpecificAppData.remoteCommand)) {
+    return familySpecificAppData;
+  }
+  return resolvedShortcut.shortcutData;
+}
+
+
+function getShortcutFriendlyName(appkey, deviceFamily, translateFunc = (name) => name) {
+  if(!appmap.has(appkey)) {
+    return '';
+  }
+  var shortcutData = appmap.get(appkey);
+  var friendlyName = translateFunc(shortcutData.friendlyName || appkey);
+  var familySpecificAppData = shortcutData[deviceFamily];
+  if(!(familySpecificAppData) || !(familySpecificAppData.alias)) {
+    return friendlyName;
+  }
+  var resolvedShortcut = resolveAppAlias(appkey, deviceFamily);
+  if(!(resolvedShortcut) || resolvedShortcut.appkey == appkey) {
+    return friendlyName;
+  }
+  var aliasFriendlyName = translateFunc(resolvedShortcut.shortcutData.friendlyName || resolvedShortcut.appkey);
+  if(aliasFriendlyName == friendlyName) {
+    return friendlyName;
+  }
+  return friendlyName+' ('+aliasFriendlyName+')';
+}
+
+
+function shortcutSupportsDeviceFamily(appkey, deviceFamily) {
+  if(!appmap.has(appkey)) {
+    return false;
+  }
+  var shortcutData = appmap.get(appkey);
+  return (shortcutData.deviceFamily && shortcutData.deviceFamily.includes(deviceFamily)) || Boolean(shortcutData[deviceFamily]) || !(shortcutData.deviceFamily);
+}
+
+
 function handlehdmi(config, inputs = 0) {
   if( inputs > 0 ) {
     for (let i = 1; i <= inputs; i++) {
@@ -3573,17 +3631,16 @@ class FiremoteCard extends LitElement {
       if(appmap.has(configvalue)) {
         var deviceFamily = config["device_family"];
         var familySpecificAppData = appmap.get(configvalue)[deviceFamily];
+        var launchData = getShortcutLaunchData(configvalue, deviceFamily);
         if(want=="active") {
           if (config["device_type"]=="fire_tv_stick_4k_max_second_gen" || config["device_type"]=="fire_tv_stick_4k_second_gen") {
               return "appActiveUnknown";
           }
           if (typeof appId != 'string') { return };
-          if(familySpecificAppData && !(appmap.get(configvalue).androidName) && !(appmap.get(configvalue).androidName2) && !(appmap.get(configvalue).appName)) {
-            return (appId == familySpecificAppData["androidName"] || appId == familySpecificAppData["androidName2"] || appId == familySpecificAppData["appName"]) ? "appActive" : "";
+          if(launchData) {
+            return (appId == launchData["androidName"] || appId == launchData["androidName2"] || appId == launchData["appName"]) ? "appActive" : "";
           }
-          else {
-            return (appId == appmap.get(configvalue).androidName || appId == appmap.get(configvalue).androidName2) || appId == appmap.get(configvalue).appName ? "appActive" : "";
-          }
+          return "";
         }
         else {
           if (appmap.get(configvalue)[want]) {
@@ -5919,17 +5976,13 @@ class FiremoteCard extends LitElement {
     // No HOLD actions for app launchers are supported
     const appkey = buttonID.substr(0, buttonID.indexOf("-button"));
     if(appmap.has(appkey)) {
-      var familySpecificAppData = appmap.get(appkey)[deviceFamily];
-      if(familySpecificAppData && (familySpecificAppData.adbLaunchCommand || familySpecificAppData.appName || familySpecificAppData.remoteCommand)) {
-        var adbcommand = familySpecificAppData.adbLaunchCommand;
-        var sourceName = familySpecificAppData.appName;
-        var remoteCommand = familySpecificAppData.remoteCommand;
+      var launchData = getShortcutLaunchData(appkey, deviceFamily);
+      if(!(launchData) || !(launchData.adbLaunchCommand || launchData.appName || launchData.remoteCommand)) {
+        return;
       }
-      else {
-        var adbcommand = appmap.get(appkey).adbLaunchCommand;
-        var sourceName = appmap.get(appkey).appName;
-        var remoteCommand = appmap.get(appkey).remoteCommand
-      }
+      var adbcommand = launchData.adbLaunchCommand;
+      var sourceName = launchData.appName;
+      var remoteCommand = launchData.remoteCommand;
       sourceName = translateToUsrLang(sourceName);
       fireEvent(this, 'haptic', 'light');
       if (typeof remoteCommand != 'undefined' && ['apple-tv', 'roku'].includes(deviceFamily)) {
@@ -8347,8 +8400,8 @@ class FiremoteCardEditor extends LitElement {
             >
               ${blankOption}
               ${appkeys.map((app) => {
-               var userLanguageAppName = this.translateToUsrLang(appmap.get(app).friendlyName);
-               if ((appmap.get(app).deviceFamily && appmap.get(app).deviceFamily.includes(family)) || !(appmap.get(app).deviceFamily)) {
+               var userLanguageAppName = getShortcutFriendlyName(app, family, (name) => this.translateToUsrLang(name));
+               if (shortcutSupportsDeviceFamily(app, family)) {
                 if (app != optionvalue) {
                   return html`<option value="${app}">${userLanguageAppName}</option> `
                 }

--- a/dist/launcher-buttons.js
+++ b/dist/launcher-buttons.js
@@ -4313,6 +4313,9 @@ const launcherData = {
           "androidName": "org.jellyfin.androidtv",
           "adbLaunchCommand": "adb shell am start -n org.jellyfin.androidtv/.ui.startup.StartupActivity",
       },
+      "apple-tv": {
+          "alias": "swiftfin",
+      },
    },
 
 


### PR DESCRIPTION
The official Jellyfin app for iOS is called Jellyfin for Mobile by Anthony Lavado however it is not available on Apple TV.

Anthony Lavado does however create Swiftfin, a Jellyfin client for Apple TV.  It even has the identifier "Jellyfin".  This is confused further due to the fact that the name of the app on the App Store is Swiftfin, however after installiing, it is displayed on the Apple TV interface as "Jellyfin".  It's very easy to forget (as I did and I believe others have) that the app we're using is not actually called Jellyfin, what with that being its name in the main menu.

This confusion can be seen in the name of a previously closed issue stating that JellyFin is the second name for Swiftfin: https://github.com/PRProd/HA-Firemote/issues/568

To resolve this, I've created the ability to add aliases for apps in the Launcher Button file.  This allows Swiftfin to be listed only once, however it also allows the Swiftfin definition to be referenced on the Jellyfin app also, without redefining it.  The result is that on Apple TV remotes, the dropdown shows both Swiftfin as its own app (as is already the case) but also shows it listed as Jellyfin.  Where such an alias is used, the name of the app is shown as "App Name (Alias App Name)".  For example, for this app, we have "Jellyfin (Swiftfin)".

I've tried to do this in a way that hopefully will be useful for other similar situations, should they appear.

<img width="1669" height="939" alt="Screenshot 2026-03-13 at 11 51 03" src="https://github.com/user-attachments/assets/f5abc8e9-a561-4631-8529-7811b801e5c6" /> Here Swiftfin is listed when searching for Jellyfin in the app store.

<img width="1669" height="939" alt="Screenshot 2026-03-13 at 11 51 29" src="https://github.com/user-attachments/assets/590de7ed-6943-4d16-a404-29fd3bb8ac1c" /> After installing Swiftfin, it is actually displayed in the Apple TV interface as "Jellyfin".


<img width="1002" height="880" alt="Screenshot 2026-03-13 at 18 59 40" src="https://github.com/user-attachments/assets/1f8c5229-636a-4825-8a67-d904681936d9" /> The solution in action (note that the original icon is used when using the alias listing, so the Jellyfin icon is displayed, but if I'd chosen Swiftfin, the Swiftfin icon would be displayed).
