### PR TITLE
Fix Molotov launch command after Fubo acquisition

### DIFF
--- a/dist/launcher-buttons.js
+++ b/dist/launcher-buttons.js
@@ -4964,7 +4964,7 @@ const launcherData = {
       "amazon-fire": {
           "appName": "tv.molotov.app",
           "androidName": "tv.molotov.app",
-          "adbLaunchCommand": "adb shell am start -n tv.molotov.app/tv.molotov.android.main.MainActivity",
+          "adbLaunchCommand": "adb shell monkey -p tv.molotov.app -c android.intent.category.LAUNCHER 1",
       },
       "apple-tv": {
           "appName": "MolotovTV",
@@ -4972,27 +4972,27 @@ const launcherData = {
       "chromecast": {
           "appName": "tv.molotov.app",
           "androidName": "tv.molotov.app",
-          "adbLaunchCommand": "adb shell am start -n tv.molotov.app/tv.molotov.android.main.MainActivity",
+          "adbLaunchCommand": "adb shell monkey -p tv.molotov.app -c android.intent.category.LAUNCHER 1",
       },
       "homatics": {
           "appName": "Molotov",
           "androidName": "tv.molotov.app",
-          "adbLaunchCommand": "adb shell am start -n tv.molotov.app/tv.molotov.android.main.MainActivity",
+          "adbLaunchCommand": "adb shell monkey -p tv.molotov.app -c android.intent.category.LAUNCHER 1",
       },
       "nvidia-shield": {
           "appName": "tv.molotov.app",
           "androidName": "tv.molotov.app",
-          "adbLaunchCommand": "adb shell am start -n tv.molotov.app/tv.molotov.android.main.MainActivity",
+          "adbLaunchCommand": "adb shell monkey -p tv.molotov.app -c android.intent.category.LAUNCHER 1",
       },
       "onn": {
           "appName": "tv.molotov.app",
           "androidName": "tv.molotov.app",
-          "adbLaunchCommand": "adb shell am start -n tv.molotov.app/tv.molotov.android.main.MainActivity",
+          "adbLaunchCommand": "adb shell monkey -p tv.molotov.app -c android.intent.category.LAUNCHER 1",
       },
       "xiaomi": {
           "appName": "tv.molotov.app",
           "androidName": "tv.molotov.app",
-          "adbLaunchCommand": "adb shell am start -n tv.molotov.app/tv.molotov.android.main.MainActivity",
+          "adbLaunchCommand": "adb shell monkey -p tv.molotov.app -c android.intent.category.LAUNCHER 1",
       },
    },
 


### PR DESCRIPTION
## Problem

The Molotov app no longer launches on Android-based devices. The current `adbLaunchCommand` uses `am start -n tv.molotov.app/tv.molotov.android.main.MainActivity`, which fails with:
Error type 3
Error: Activity class {tv.molotov.app/tv.molotov.android.main.MainActivity} does not exist.

This is because Molotov was acquired by Fubo and the app was rebuilt on top of the Fubo codebase. The main activity was renamed to:
tv.fubo.mobile.presentation.onboarding.dispatch.controller.DispatchActivity

## Fix

Replaced the explicit `am start -n ...` command with:
adb shell monkey -p tv.molotov.app -c android.intent.category.LAUNCHER 1

This launches the app by package name + LAUNCHER category, equivalent to clicking its icon in the Android launcher. It bypasses the activity-name issue entirely and should be resilient to future renames as Molotov/Fubo continues to merge their codebases.

Applied to all Android-based device families: `amazon-fire`, `chromecast`, `homatics`, `nvidia-shield`, `onn`, `xiaomi`. `apple-tv` is unchanged since it uses a different mechanism.

## Testing

Tested on NVIDIA Shield TV Pro 2019 with the Home Assistant `androidtv` integration. App launches correctly from the firemote card. Verified via `dumpsys window windows` that the Fubo activity is what gets resolved when launching by package name.