### PR TITLE
Fix invalid calc() that silently dropped two box-shadows

### DIFF
--- a/dist/HA-Firemote.js
+++ b/dist/HA-Firemote.js
@@ -1182,7 +1182,7 @@ class FiremoteCard extends LitElement {
             align-content: center;
             color: rgb(198 198 198);
             background: rgb(33 33 33);
-            box-shadow: rgb(0 0 0 / 13%) 0 calc(var(--sz) * 0.214rem) calc(var(--sz) * 0.143rem 0);
+            box-shadow: rgb(0 0 0 / 13%) 0 calc(var(--sz) * 0.214rem) calc(var(--sz) * 0.143rem) 0;
             cursor: pointer;
             line-height: normal;
             user-select: none;
@@ -1868,7 +1868,7 @@ class FiremoteCard extends LitElement {
 
           .apple-remote-body .srcButton {
             border: none;
-            box-shadow: rgb(0 0 0 / 13%) 0 calc(var(--sz) * 0.214rem) calc(var(--sz) * 0.143rem 0);
+            box-shadow: rgb(0 0 0 / 13%) 0 calc(var(--sz) * 0.214rem) calc(var(--sz) * 0.143rem) 0;
             transition: none;
           }
 


### PR DESCRIPTION
The blur radius and the spread value are both inside `calc()`:

```css
box-shadow: rgb(0 0 0 / 13%) 0 calc(var(--sz) * 0.214rem) calc(var(--sz) * 0.143rem 0);
```

`calc()` takes a single expression, so the trailing `0` makes the function invalid. Per CSS error handling the browser discards the **entire** `box-shadow` declaration rather than just that value.

Two rules are affected:

| line | selector |
|---|---|
| 1185 | `.remote-button` |
| 1871 | `.apple-remote-body .srcButton` |

Both render without any shadow today. It is easiest to see on the Chromecast skin, where the app launcher buttons cast a shadow but the round buttons right next to them do not, even though both were written to have one.

The fix moves the spread value outside the parentheses:

```css
box-shadow: rgb(0 0 0 / 13%) 0 calc(var(--sz) * 0.214rem) calc(var(--sz) * 0.143rem) 0;
```

That is the same form the other twenty `box-shadow` declarations in this stylesheet already use, so the intended values are unchanged — they simply take effect now.

Found while styling a Chromecast remote and wondering why only some buttons had shadows.