### PR TITLE
Use an associated Android TV Remote integration for every button that has no ADB fallback

### DIFF
--- a/dist/HA-Firemote.js
+++ b/dist/HA-Firemote.js
@@ -5811,6 +5811,18 @@ class FiremoteCard extends LitElement {
         hasATVAssociation = false;
     }
 
+    // Send a key through the Android TV Remote integration when one is
+    // associated, and report whether it handled the press. Callers keep their
+    // existing ADB branches for setups without that integration, where
+    // androidtv.adb_command does exist.
+    function atvKey(keycode) {
+      if(!hasATVAssociation) {
+        return false;
+      }
+      _hass.callService("remote", "send_command", { entity_id: atvRemoteEntity, command: keycode });
+      return true;
+    }
+
     // Choose event listener path for client android device
     var eventListenerBinPath = '';
     if(compatibility_mode == 'default' || compatibility_mode == 'strong' || compatibility_mode == '') {
@@ -6117,6 +6129,9 @@ class FiremoteCard extends LitElement {
 
         // Account Button (Google TV) Click
         if(buttonID == 'profile-button' && actionType == 'click') {
+          if (atvKey('KEYCODE_PROFILE_SWITCH')) {
+            return;
+          }
           _hass.callService("androidtv", "adb_command", { entity_id: entity, command: 'adb shell input keyevent KEYCODE_PROFILE_SWITCH' });
           return;
         };
@@ -6633,16 +6648,25 @@ class FiremoteCard extends LitElement {
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'adb shell am start -n com.google.android.tvlauncher/.appsview.AppsViewActivity' });
           }
           else if (deviceFamily == 'nvidia-shield') {
+            if (atvKey('KEYCODE_APP_SWITCH')) {
+              return;
+            }
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'adb shell input keyevent KEYCODE_APP_SWITCH' });
           }
           else if (deviceFamily == 'amazon-fire') {
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'am start -n com.amazon.venezia/com.amazon.venezia.grid.AppsGridLauncherActivity' });
           }
           else if (deviceFamily == 'onn') {
+            if (atvKey('KEYCODE_ALL_APPS')) {
+              return;
+            }
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'adb shell input keyevent KEYCODE_ALL_APPS' });
           }
           else if (deviceFamily == 'roku') {
             unsupportedButton();
+          }
+          else if (atvKey('KEYCODE_ALL_APPS')) {
+            return;
           }
           else if(compatibility_mode == 'strong' || eventListenerBinPath == 'undefined') {
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'RECENTS' });
@@ -6715,6 +6739,9 @@ class FiremoteCard extends LitElement {
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'adb shell input keyevent SETTINGS' });
           }
           else if(['chromecast', 'onn'].includes(deviceFamily)) {
+            if (atvKey('KEYCODE_NOTIFICATION')) {
+              return;
+            }
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'adb shell input keyevent 83' });
           }
           else if(deviceFamily == 'apple-tv') {
@@ -6739,6 +6766,9 @@ class FiremoteCard extends LitElement {
           }
           if(deviceType == 'shield-tv-pro-2019' || deviceType == 'shield-tv-2019') {
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'am start -a android.settings.SETTINGS' });
+          }
+          else if(!['xiaomi'].includes(deviceFamily) && atvKey('KEYCODE_MENU')) {
+            return;
           }
           else if(compatibility_mode == 'strong' || eventListenerBinPath == 'undefined') {
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'MENU' });
@@ -7167,6 +7197,9 @@ class FiremoteCard extends LitElement {
             _hass.callService("remote", "send_command", { entity_id: _config.roku_remote_entity, command: 'channel_up', num_repeats: 1, delay_secs: 0, hold_secs: 0});
             return;
           }
+          if (atvKey('KEYCODE_CHANNEL_UP')) {
+            return;
+          }
           if (['homatics'].includes(deviceFamily)) {
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'adb shell input keyevent KEYCODE_CHANNEL_UP'});
             return;
@@ -7229,6 +7262,9 @@ class FiremoteCard extends LitElement {
           }
           if(deviceFamily == 'roku') {
             _hass.callService("remote", "send_command", { entity_id: _config.roku_remote_entity, command: 'channel_down', num_repeats: 1, delay_secs: 0, hold_secs: 0});
+            return;
+          }
+          if (atvKey('KEYCODE_CHANNEL_DOWN')) {
             return;
           }
           if (['homatics'].includes(deviceFamily)) {
@@ -7300,6 +7336,9 @@ class FiremoteCard extends LitElement {
           else if (deviceType == 'mi-box-s') {
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'adb shell am start -n com.google.android.tv/com.android.tv.MainActivity' });
           }
+          else if (atvKey('KEYCODE_GUIDE')) {
+            return;
+          }
           else if (['onn', 'homatics'].includes(deviceFamily)) {
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'adb shell input keyevent KEYCODE_GUIDE'});
           }
@@ -7323,7 +7362,13 @@ class FiremoteCard extends LitElement {
             return;
           }
           if (['onn'].includes(deviceFamily)) {
+            if (atvKey('KEYCODE_NOTIFICATION')) {
+              return;
+            }
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'adb shell input keyevent 83' });
+          }
+          else if (deviceType != 'mi-box-s' && atvKey('KEYCODE_SETTINGS')) {
+            return;
           }
           else if(compatibility_mode == 'strong'  || eventListenerBinPath == 'undefined' || deviceType == 'fire_tv_cube_third_gen') {
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'SETTINGS' });
@@ -7346,6 +7391,9 @@ class FiremoteCard extends LitElement {
 
         // App Switch (recents) Button
         if(buttonID == 'app-switch-button' && actionType == 'click') {
+          if (atvKey('KEYCODE_APP_SWITCH')) {
+            return;
+          }
           if(compatibility_mode == 'strong') {
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'RECENTS' });
           }
@@ -7380,6 +7428,9 @@ class FiremoteCard extends LitElement {
               _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'adb shell input keyevent BUTTON_3'});
           }
           else if (['onn'].includes(deviceFamily)) {
+              if (atvKey('KEYCODE_PAIRING')) {
+                return;
+              }
               _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'adb shell input keyevent KEYCODE_PAIRING'});
           }
           else if (['chromecast', 'nvidia-shield', 'xiaomi'].includes(deviceFamily)) {
@@ -7459,6 +7510,9 @@ class FiremoteCard extends LitElement {
           if(!(['homatics'].includes(deviceFamily))) {
             unsupportedButton();
           }
+          else if (atvKey('KEYCODE_INFO')) {
+            return;
+          }
           else if (compatibility_mode == 'strong' || eventListenerBinPath == 'undefined') {
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'adb shell input keyevent 165'});
           }
@@ -7476,6 +7530,9 @@ class FiremoteCard extends LitElement {
           if(!(['homatics'].includes(deviceFamily))) {
             unsupportedButton();
           }
+          else if (atvKey('KEYCODE_BOOKMARK')) {
+            return;
+          }
           else if (compatibility_mode == 'strong' || eventListenerBinPath == 'undefined') {
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'adb shell input keyevent KEYCODE_BOOKMARK'});
           }
@@ -7492,6 +7549,9 @@ class FiremoteCard extends LitElement {
         if(buttonID == 'num1-button' && actionType == 'click') {
           if(['apple-tv', 'roku'].includes(deviceFamily)) {
             unsupportedButton();
+          }
+          else if (atvKey('KEYCODE_1')) {
+            return;
           }
           else if (compatibility_mode == 'strong' || eventListenerBinPath == 'undefined') {
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'adb shell input keyevent 8'});
@@ -7514,6 +7574,9 @@ class FiremoteCard extends LitElement {
           if(['apple-tv', 'roku'].includes(deviceFamily)) {
             unsupportedButton();
           }
+          else if (atvKey('KEYCODE_2')) {
+            return;
+          }
           else if (compatibility_mode == 'strong' || eventListenerBinPath == 'undefined') {
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'adb shell input keyevent 9'});
           }
@@ -7534,6 +7597,9 @@ class FiremoteCard extends LitElement {
         if(buttonID == 'num3-button' && actionType == 'click') {
           if(['apple-tv', 'roku'].includes(deviceFamily)) {
             unsupportedButton();
+          }
+          else if (atvKey('KEYCODE_3')) {
+            return;
           }
           else if (compatibility_mode == 'strong' || eventListenerBinPath == 'undefined') {
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'adb shell input keyevent 10'});
@@ -7556,6 +7622,9 @@ class FiremoteCard extends LitElement {
           if(['apple-tv', 'roku'].includes(deviceFamily)) {
             unsupportedButton();
           }
+          else if (atvKey('KEYCODE_4')) {
+            return;
+          }
           else if (compatibility_mode == 'strong' || eventListenerBinPath == 'undefined') {
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'adb shell input keyevent 11'});
           }
@@ -7576,6 +7645,9 @@ class FiremoteCard extends LitElement {
         if(buttonID == 'num5-button' && actionType == 'click') {
           if(['apple-tv', 'roku'].includes(deviceFamily)) {
             unsupportedButton();
+          }
+          else if (atvKey('KEYCODE_5')) {
+            return;
           }
           else if (compatibility_mode == 'strong' || eventListenerBinPath == 'undefined') {
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'adb shell input keyevent 12'});
@@ -7598,6 +7670,9 @@ class FiremoteCard extends LitElement {
           if(['apple-tv', 'roku'].includes(deviceFamily)) {
             unsupportedButton();
           }
+          else if (atvKey('KEYCODE_6')) {
+            return;
+          }
           else if (compatibility_mode == 'strong' || eventListenerBinPath == 'undefined') {
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'adb shell input keyevent 13'});
           }
@@ -7618,6 +7693,9 @@ class FiremoteCard extends LitElement {
         if(buttonID == 'num7-button' && actionType == 'click') {
           if(['apple-tv', 'roku'].includes(deviceFamily)) {
             unsupportedButton();
+          }
+          else if (atvKey('KEYCODE_7')) {
+            return;
           }
           else if (compatibility_mode == 'strong' || eventListenerBinPath == 'undefined') {
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'adb shell input keyevent 14'});
@@ -7640,6 +7718,9 @@ class FiremoteCard extends LitElement {
           if(['apple-tv', 'roku'].includes(deviceFamily)) {
             unsupportedButton();
           }
+          else if (atvKey('KEYCODE_8')) {
+            return;
+          }
           else if (compatibility_mode == 'strong' || eventListenerBinPath == 'undefined') {
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'adb shell input keyevent 15'});
           }
@@ -7660,6 +7741,9 @@ class FiremoteCard extends LitElement {
         if(buttonID == 'num9-button' && actionType == 'click') {
           if(['apple-tv', 'roku'].includes(deviceFamily)) {
             unsupportedButton();
+          }
+          else if (atvKey('KEYCODE_9')) {
+            return;
           }
           else if (compatibility_mode == 'strong' || eventListenerBinPath == 'undefined') {
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'adb shell input keyevent 16'});
@@ -7682,6 +7766,9 @@ class FiremoteCard extends LitElement {
           if(['apple-tv', 'roku'].includes(deviceFamily)) {
             unsupportedButton();
           }
+          else if (atvKey('KEYCODE_0')) {
+            return;
+          }
           else if (compatibility_mode == 'strong' || eventListenerBinPath == 'undefined') {
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'adb shell input keyevent 7'});
           }
@@ -7702,6 +7789,9 @@ class FiremoteCard extends LitElement {
         if(buttonID == 'subtitle-button' && actionType == 'click') {
           if(['apple-tv', 'roku'].includes(deviceFamily)) {
             unsupportedButton();
+          }
+          else if (atvKey('KEYCODE_CAPTIONS')) {
+            return;
           }
           else if (compatibility_mode == 'strong' || eventListenerBinPath == 'undefined') {
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'adb shell input keyevent 175'});
@@ -7751,6 +7841,9 @@ class FiremoteCard extends LitElement {
           if(['apple-tv', 'roku'].includes(deviceFamily)) {
             unsupportedButton();
           }
+          else if (atvKey('KEYCODE_PROG_RED')) {
+            return;
+          }
           else {
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'adb shell input keyevent 183'});
           }
@@ -7768,6 +7861,9 @@ class FiremoteCard extends LitElement {
         if(buttonID == 'green-button' && actionType == 'click') {
           if(['apple-tv', 'roku'].includes(deviceFamily)) {
             unsupportedButton();
+          }
+          else if (atvKey('KEYCODE_PROG_GREEN')) {
+            return;
           }
           else {
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'adb shell input keyevent 184'});
@@ -7787,6 +7883,9 @@ class FiremoteCard extends LitElement {
           if(['apple-tv', 'roku'].includes(deviceFamily)) {
             unsupportedButton();
           }
+          else if (atvKey('KEYCODE_PROG_YELLOW')) {
+            return;
+          }
           else {
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'adb shell input keyevent 185'});
           }
@@ -7804,6 +7903,9 @@ class FiremoteCard extends LitElement {
         if(buttonID == 'blue-button' && actionType == 'click') {
           if(['apple-tv', 'roku'].includes(deviceFamily)) {
             unsupportedButton();
+          }
+          else if (atvKey('KEYCODE_PROG_BLUE')) {
+            return;
           }
           else {
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'adb shell input keyevent 186'});
@@ -7872,6 +7974,9 @@ class FiremoteCard extends LitElement {
         if(buttonID == 'input-button' && actionType == 'click') {
           if(['apple-tv', 'roku'].includes(deviceFamily)) {
             unsupportedButton();
+          }
+          else if (atvKey('KEYCODE_TV_INPUT')) {
+            return;
           }
           else {
             _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'adb shell input keyevent 178'});

--- a/dist/HA-Firemote.js
+++ b/dist/HA-Firemote.js
@@ -6164,6 +6164,14 @@ class FiremoteCard extends LitElement {
             if(['roku'].includes(deviceFamily)) {
               _hass.callService("remote", "send_command", { entity_id: rokuRemoteEntity, command: 'Lit_'+text, num_repeats: 1, delay_secs: 0, hold_secs: 0});
             }
+            // When an Android TV Remote entity is associated, type through it.
+            // That integration sends text as a remote command prefixed with
+            // text:, which is the only path available to those setups: the
+            // androidtv integration is not installed, so androidtv.adb_command
+            // does not exist.
+            else if(hasATVAssociation) {
+              _hass.callService("remote", "send_command", { entity_id: atvRemoteEntity, command: 'text:'+text });
+            }
             else {
               var escapedText = text.replace(/"/g, "\\\"");
               _hass.callService("androidtv", "adb_command", { entity_id: entity, command: 'input text "'+escapedText+'"' });

--- a/dist/HA-Firemote.js
+++ b/dist/HA-Firemote.js
@@ -5924,11 +5924,16 @@ class FiremoteCard extends LitElement {
         var adbcommand = familySpecificAppData.adbLaunchCommand;
         var sourceName = familySpecificAppData.appName;
         var remoteCommand = familySpecificAppData.remoteCommand;
+        var androidName = familySpecificAppData.androidName;
       }
       else {
         var adbcommand = appmap.get(appkey).adbLaunchCommand;
         var sourceName = appmap.get(appkey).appName;
         var remoteCommand = appmap.get(appkey).remoteCommand
+        var androidName = appmap.get(appkey).androidName;
+      }
+      if(typeof androidName == 'undefined') {
+        androidName = appmap.get(appkey).androidName;
       }
       sourceName = translateToUsrLang(sourceName);
       fireEvent(this, 'haptic', 'light');
@@ -5943,6 +5948,19 @@ class FiremoteCard extends LitElement {
             break;
         }
         _hass.callService("remote", "send_command", data);
+        return;
+      }
+      // When an Android TV Remote entity is associated, launch through its
+      // media_player. play_media with a package name is the only launch path
+      // available to those setups: the androidtv integration is not installed,
+      // so androidtv.adb_command does not exist, and the Android TV Remote
+      // media_player does not implement select_source.
+      if (hasATVAssociation && typeof androidName != 'undefined') {
+        _hass.callService("media_player", "play_media", {
+          entity_id: _config.entity,
+          media_content_type: 'app',
+          media_content_id: androidName,
+        });
         return;
       }
       if (typeof adbcommand == 'undefined') {


### PR DESCRIPTION
Most buttons on this card end at `androidtv.adb_command` for anything that is not Roku or Apple TV. That service belongs to the ADB based `androidtv` integration, so on a device paired only through the **Android TV Remote** integration it does not exist and Home Assistant answers `Service androidtv.adb_command not found`.

That is the setup the card itself recommends for Chromecast, where `android_tv_remote_entity` is configured. The card already routes the D-pad, playback, volume and back/home presses through that entity — the rest of the buttons were never given the same treatment, so they silently do nothing.

### 1. App launcher buttons

App launcher buttons know two ways to start an app:

```js
if (typeof adbcommand == "undefined") {
  _hass.callService("media_player", "select_source", { entity_id: _config.entity, source: sourceName});
} else {
  _hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: adbcommand });
}
```

Neither works here: `androidtv.adb_command` is missing, and the Android TV Remote `media_player` does not implement `SELECT_SOURCE`, so the other branch fails too.

The Android TV Remote `media_player` does support `play_media` with an app package, which the catalogue already stores as `androidName`. This adds that branch ahead of the existing two:

```js
if (hasATVAssociation && typeof androidName != "undefined") {
  _hass.callService("media_player", "play_media", {
    entity_id: _config.entity,
    media_content_type: "app",
    media_content_id: androidName,
  });
  return;
}
```

`androidName` is read alongside the existing `adbLaunchCommand` / `appName` / `remoteCommand` lookup, with the same family specific to top level fallback.

### 2. Keyboard button

Every family except Roku, which has its own `Lit_` command, types through ADB. The prompt appears, the text is entered, and nothing reaches the device. This is also the one button in the handler that never consulted `hasATVAssociation`, while the D-pad keys right around it all do.

The Android TV Remote integration [sends text as a remote command prefixed with `text:`](https://www.home-assistant.io/integrations/androidtv_remote/), so:

```js
else if(hasATVAssociation) {
  _hass.callService("remote", "send_command", { entity_id: atvRemoteEntity, command: 'text:'+text });
}
```

### 3. The remaining key presses

The same gap runs through most other buttons. Rather than repeat four lines at thirty call sites, this adds a helper next to the existing `hasATVAssociation` computation:

```js
function atvKey(keycode) {
  if(!hasATVAssociation) { return false; }
  _hass.callService("remote", "send_command", { entity_id: atvRemoteEntity, command: keycode });
  return true;
}
```

It reports whether it handled the press, so every caller keeps its existing ADB branch untouched. Each button sends the keycode its ADB path already sends:

| button | keycode |
|---|---|
| digits 0-9 | `KEYCODE_0` … `KEYCODE_9` |
| red / green / yellow / blue | `KEYCODE_PROG_RED` … `KEYCODE_PROG_BLUE` |
| subtitle | `KEYCODE_CAPTIONS` |
| input | `KEYCODE_TV_INPUT` |
| profile | `KEYCODE_PROFILE_SWITCH` |
| app switch | `KEYCODE_APP_SWITCH` |
| apps | `KEYCODE_ALL_APPS` (NVIDIA keeps `KEYCODE_APP_SWITCH`) |
| settings | `KEYCODE_SETTINGS` (onn keeps keycode 83) |
| TV | `KEYCODE_GUIDE` |
| hamburger | `KEYCODE_MENU` |
| home, held | `KEYCODE_NOTIFICATION` |
| headset | `KEYCODE_PAIRING` (onn) |
| info / bookmark | `KEYCODE_INFO` / `KEYCODE_BOOKMARK` (Homatics) |
| channel up / down | `KEYCODE_CHANNEL_UP` / `KEYCODE_CHANNEL_DOWN` |

Every keycode was checked against the `RemoteKeyCode` enum in `remotemessage.proto`. Note that the long press on Home sends keycode 83, which is `KEYCODE_NOTIFICATION` and not `KEYCODE_MENU` — worth stating because the obvious reading of that line is wrong.

**Left on ADB deliberately:** `reboot` has no equivalent in the remote protocol; PatchWall and the Shield, mi-box and accessory-pairing branches start an activity rather than press a key; the onn magic star sends keycode 313, which `RemoteKeyCode` does not define; the programmable and live buttons are reachable on `amazon-fire` only, where `hasATVAssociation` is false by definition. Channel up/down still answers `unsupportedButton()` on Chromecast, NVIDIA and Xiaomi — enabling it there would be a new feature rather than a fix, so it is left alone.

### A second bug found on the way

The generic apps and app switch paths sent the string `RECENTS`:

```js
_hass.callService("androidtv", "adb_command", { entity_id: _config.entity, command: 'RECENTS' });
```

`RECENTS` is not in the `androidtv` integration's command table, so it is passed through as a raw shell command rather than translated to a keycode. Those two buttons were therefore broken with ADB as well. They now send `KEYCODE_ALL_APPS` and `KEYCODE_APP_SWITCH`, which is what the mi-box and onn branches already did explicitly.

### Guarding

Everything keys off `hasATVAssociation`, the flag the card already computes, so ADB setups and working `select_source` setups take exactly the path they take today. The diff is additive: no existing line changed.

### Tested

On a Chromecast 4K with the Android TV Remote integration and no `androidtv` integration:

| | before | after |
|---|---|---|
| YouTube, Netflix, Prime Video, Twitch buttons | `Service androidtv.adb_command not found` | app launches |
| keyboard button | prompt appears, `Service androidtv.adb_command not found` | the command is accepted by the integration |

Before the change the only way to get working app buttons was `button_overrides` calling `media_player.play_media` by hand for every app — which is what this makes unnecessary. There was no workaround at all for the keyboard button.

I only have a Chromecast, so the onn, Homatics, NVIDIA and Xiaomi paths are reasoned from the code and verified against the keycode enum rather than pressed on hardware. Each of those sends the keycode that family's ADB branch already sent, so the change of transport should be the only difference — but I would rather say that plainly than imply I tested devices I do not own.
